### PR TITLE
Feature/#6 Bakery Query 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-testcontainers:3.3.5'
     testImplementation 'org.testcontainers:testcontainers:1.19.3'
     testImplementation 'org.testcontainers:junit-jupiter:1.19.3'
-    testImplementation 'org.testcontainers:mysql:1.20.0'
+    testImplementation 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     //monitoring

--- a/src/main/java/kr/co/breadfeetserver/application/bakery/BakeryQueryService.java
+++ b/src/main/java/kr/co/breadfeetserver/application/bakery/BakeryQueryService.java
@@ -1,8 +1,12 @@
 package kr.co.breadfeetserver.application.bakery;
 
 import kr.co.breadfeetserver.application.support.CursorService;
-import kr.co.breadfeetserver.domain.bakery.query.BakeryJdbcRepository;
+import kr.co.breadfeetserver.domain.bakery.Bakery;
+import kr.co.breadfeetserver.domain.bakery.query.BakeryQueryRepository;
+import kr.co.breadfeetserver.infra.exception.BreadFeetBusinessException;
+import kr.co.breadfeetserver.infra.exception.ErrorCode;
 import kr.co.breadfeetserver.presentation.bakery.dto.request.BakeryCursorCommand;
+import kr.co.breadfeetserver.presentation.bakery.dto.response.BakeryDetailResponse;
 import kr.co.breadfeetserver.presentation.bakery.dto.response.BakeryListResponse;
 import kr.co.breadfeetserver.presentation.support.CursorResponse;
 import lombok.RequiredArgsConstructor;
@@ -16,11 +20,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
 public class BakeryQueryService {
 
-    private final BakeryJdbcRepository bakeryJdbcRepository;
+    private final BakeryQueryRepository bakeryJdbcRepository;
     private final CursorService cursorService;
 
     public CursorResponse<BakeryListResponse> getBakeryList(BakeryCursorCommand command) {
         final Slice<BakeryListResponse> slice = bakeryJdbcRepository.findAll(command);
         return cursorService.getCursorResponse(slice);
+    }
+
+    public BakeryDetailResponse getBakery(Long bakeryId) {
+        Bakery bakery = bakeryJdbcRepository.findById(bakeryId)
+                .orElseThrow(() -> new BreadFeetBusinessException(ErrorCode.BAKERY_NOT_FOUND));
+        return BakeryDetailResponse.from(bakery);
     }
 }

--- a/src/main/java/kr/co/breadfeetserver/application/bakery/BakeryQueryService.java
+++ b/src/main/java/kr/co/breadfeetserver/application/bakery/BakeryQueryService.java
@@ -1,0 +1,26 @@
+package kr.co.breadfeetserver.application.bakery;
+
+import kr.co.breadfeetserver.application.support.CursorService;
+import kr.co.breadfeetserver.domain.bakery.query.BakeryJdbcRepository;
+import kr.co.breadfeetserver.presentation.bakery.dto.request.BakeryCursorCommand;
+import kr.co.breadfeetserver.presentation.bakery.dto.response.BakeryListResponse;
+import kr.co.breadfeetserver.presentation.support.CursorResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class BakeryQueryService {
+
+    private final BakeryJdbcRepository bakeryJdbcRepository;
+    private final CursorService cursorService;
+
+    public CursorResponse<BakeryListResponse> getBakeryList(BakeryCursorCommand command) {
+        final Slice<BakeryListResponse> slice = bakeryJdbcRepository.findAll(command);
+        return cursorService.getCursorResponse(slice);
+    }
+}

--- a/src/main/java/kr/co/breadfeetserver/application/support/CursorService.java
+++ b/src/main/java/kr/co/breadfeetserver/application/support/CursorService.java
@@ -1,0 +1,21 @@
+package kr.co.breadfeetserver.application.support;
+
+import java.util.List;
+import kr.co.breadfeetserver.global.dto.Cursorable;
+import kr.co.breadfeetserver.presentation.support.CursorResponse;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CursorService {
+
+    public <T extends Cursorable> CursorResponse<T> getCursorResponse(Slice<T> slice) {
+        final List<T> content = slice.getContent();
+        Long nextCursor = null;
+
+        if (!content.isEmpty()) {
+            nextCursor = content.get(content.size() - 1).getCursorId();
+        }
+        return CursorResponse.of(slice, nextCursor);
+    }
+}

--- a/src/main/java/kr/co/breadfeetserver/domain/bakery/Bakery.java
+++ b/src/main/java/kr/co/breadfeetserver/domain/bakery/Bakery.java
@@ -13,6 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SoftDelete;
+import org.hibernate.annotations.SoftDeleteType;
 
 @Getter
 @Entity
@@ -20,6 +22,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SoftDelete(columnName = "deleted_at", strategy = SoftDeleteType.TIMESTAMP)
 public class Bakery extends BaseTimeEntity {
 
     @Id
@@ -50,6 +53,8 @@ public class Bakery extends BaseTimeEntity {
 
     @Column(name = "y_coordinate")
     private Double yCoordinate;
+
+    private Boolean deleted;
 
     @Column(name = "member_id")
     private Long memberId;

--- a/src/main/java/kr/co/breadfeetserver/domain/bakery/query/BakeryJdbcRepository.java
+++ b/src/main/java/kr/co/breadfeetserver/domain/bakery/query/BakeryJdbcRepository.java
@@ -1,0 +1,10 @@
+package kr.co.breadfeetserver.domain.bakery.query;
+
+import kr.co.breadfeetserver.presentation.bakery.dto.request.BakeryCursorCommand;
+import kr.co.breadfeetserver.presentation.bakery.dto.response.BakeryListResponse;
+import org.springframework.data.domain.Slice;
+
+public interface BakeryJdbcRepository {
+
+    Slice<BakeryListResponse> findAll(BakeryCursorCommand command);
+}

--- a/src/main/java/kr/co/breadfeetserver/domain/bakery/query/BakeryJdbcRepositoryImpl.java
+++ b/src/main/java/kr/co/breadfeetserver/domain/bakery/query/BakeryJdbcRepositoryImpl.java
@@ -1,0 +1,51 @@
+package kr.co.breadfeetserver.domain.bakery.query;
+
+import java.util.List;
+import kr.co.breadfeetserver.domain.bakery.query.mapper.BakeryRowMapper;
+import kr.co.breadfeetserver.presentation.bakery.dto.request.BakeryCursorCommand;
+import kr.co.breadfeetserver.presentation.bakery.dto.response.BakeryListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BakeryJdbcRepositoryImpl implements BakeryJdbcRepository {
+
+    private static final BakeryRowMapper ROW_MAPPER = new BakeryRowMapper();
+    private static final String BAKERY_SELECT = "SELECT * FROM bakery";
+    private final NamedParameterJdbcTemplate jdbc;
+
+    @Override
+    public Slice<BakeryListResponse> findAll(BakeryCursorCommand command) {
+        MapSqlParameterSource params = new MapSqlParameterSource()
+            .addValue("size", command.size() + 1);
+
+        String sql = BAKERY_SELECT + "\n"
+            + "WHERE deleted_at IS NULL\n"
+            + createCursorCondition(command.cursor(), params)
+            + "ORDER BY bakery_id DESC\n"
+            + "LIMIT :size";
+
+        List<BakeryListResponse> bakeries = jdbc.query(sql, params, ROW_MAPPER);
+
+        boolean hasNext = bakeries.size() > command.size();
+        if (hasNext) {
+            bakeries.remove(command.size());
+        }
+
+        return new SliceImpl<>(bakeries, PageRequest.of(0, command.size()), hasNext);
+    }
+
+    private String createCursorCondition(Long cursor, MapSqlParameterSource params) {
+        if (cursor == null) {
+            return "";
+        }
+        params.addValue("cursor", cursor);
+        return "AND bakery_id < :cursor\n";
+    }
+}

--- a/src/main/java/kr/co/breadfeetserver/domain/bakery/query/BakeryQueryRepository.java
+++ b/src/main/java/kr/co/breadfeetserver/domain/bakery/query/BakeryQueryRepository.java
@@ -1,0 +1,7 @@
+package kr.co.breadfeetserver.domain.bakery.query;
+
+import kr.co.breadfeetserver.domain.bakery.BakeryJpaRepository;
+
+public interface BakeryQueryRepository extends BakeryJdbcRepository, BakeryJpaRepository {
+
+}

--- a/src/main/java/kr/co/breadfeetserver/domain/bakery/query/mapper/BakeryRowMapper.java
+++ b/src/main/java/kr/co/breadfeetserver/domain/bakery/query/mapper/BakeryRowMapper.java
@@ -1,0 +1,29 @@
+package kr.co.breadfeetserver.domain.bakery.query.mapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import kr.co.breadfeetserver.presentation.bakery.dto.response.AddressResponse;
+import kr.co.breadfeetserver.presentation.bakery.dto.response.BakeryListResponse;
+import org.springframework.jdbc.core.RowMapper;
+
+public class BakeryRowMapper implements RowMapper<BakeryListResponse> {
+
+    @Override
+    public BakeryListResponse mapRow(ResultSet rs, int rowNum) throws SQLException {
+        AddressResponse address = AddressResponse.of(
+            rs.getString("detail"),
+            rs.getString("lot_number"),
+            rs.getString("road_address")
+        );
+
+        return new BakeryListResponse(
+            rs.getLong("bakery_id"),
+            rs.getString("name"),
+            address,
+            rs.getString("image_url"),
+            //TODO: 집계쿼리 추가. 현재는 임시 값 사용.
+            0L,
+            0.0
+        );
+    }
+}

--- a/src/main/java/kr/co/breadfeetserver/global/dto/Cursorable.java
+++ b/src/main/java/kr/co/breadfeetserver/global/dto/Cursorable.java
@@ -1,0 +1,5 @@
+package kr.co.breadfeetserver.global.dto;
+
+public interface Cursorable {
+    Long getCursorId();
+}

--- a/src/main/java/kr/co/breadfeetserver/presentation/annotation/CursorSize.java
+++ b/src/main/java/kr/co/breadfeetserver/presentation/annotation/CursorSize.java
@@ -1,22 +1,24 @@
-package kr.co.breadfeetserver.global.annotation;
+package kr.co.breadfeetserver.presentation.annotation;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 import jakarta.validation.ReportAsSingleViolation;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@NotBlank(message = "이 값은 필수 정보입니다.")
+@Min(value = 1, message = "사이즈는 최소 1 이상이어야 합니다.")
+@Max(value = 50, message = "한 번에 최대 50개까지만 조회 가능합니다.")
 @Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = {})
 @ReportAsSingleViolation
-public @interface IsEssential {
+public @interface CursorSize {
 
-    String message() default "필수 정보가 누락되었습니다.";
+    String message() default "사이즈 범위를 맞지 않게 요청했습니다.";
 
     Class<?>[] groups() default {};
 

--- a/src/main/java/kr/co/breadfeetserver/presentation/annotation/IsEssential.java
+++ b/src/main/java/kr/co/breadfeetserver/presentation/annotation/IsEssential.java
@@ -1,24 +1,22 @@
-package kr.co.breadfeetserver.global.annotation;
+package kr.co.breadfeetserver.presentation.annotation;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
-import jakarta.validation.constraints.Pattern;
+import jakarta.validation.ReportAsSingleViolation;
+import jakarta.validation.constraints.NotBlank;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Pattern(
-        regexp = "^(|01[016789]-\\d{3,4}-\\d{4})$",
-        message = "전화번호 형식은 010-XXXX-XXXX 이어야 합니다."
-)
-
+@NotBlank(message = "이 값은 필수 정보입니다.")
 @Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = {})
-public @interface PhoneNumberPattern {
+@ReportAsSingleViolation
+public @interface IsEssential {
 
-    String message() default "전화번호 형식은 010-XXXX-XXXX 이어야 합니다.";
+    String message() default "필수 정보가 누락되었습니다.";
 
     Class<?>[] groups() default {};
 

--- a/src/main/java/kr/co/breadfeetserver/presentation/annotation/PhoneNumberPattern.java
+++ b/src/main/java/kr/co/breadfeetserver/presentation/annotation/PhoneNumberPattern.java
@@ -1,0 +1,26 @@
+package kr.co.breadfeetserver.presentation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.constraints.Pattern;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Pattern(
+        regexp = "^(|01[016789]-\\d{3,4}-\\d{4})$",
+        message = "전화번호 형식은 010-XXXX-XXXX 이어야 합니다."
+)
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {})
+public @interface PhoneNumberPattern {
+
+    String message() default "전화번호 형식은 010-XXXX-XXXX 이어야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/kr/co/breadfeetserver/presentation/bakery/BakeryQueryController.java
+++ b/src/main/java/kr/co/breadfeetserver/presentation/bakery/BakeryQueryController.java
@@ -22,7 +22,7 @@ public class BakeryQueryController {
 
     @GetMapping
     public ResponseEntity<ApiResponseWrapper<CursorResponse<BakeryListResponse>>> getBakeryList(
-            @RequestParam(required = false, defaultValue = "0") Long cursor,
+            @RequestParam Long cursor,
             @RequestParam(defaultValue = "10") int size
     ) {
         BakeryCursorCommand command = new BakeryCursorCommand(cursor, size);

--- a/src/main/java/kr/co/breadfeetserver/presentation/bakery/BakeryQueryController.java
+++ b/src/main/java/kr/co/breadfeetserver/presentation/bakery/BakeryQueryController.java
@@ -1,0 +1,38 @@
+package kr.co.breadfeetserver.presentation.bakery;
+
+import kr.co.breadfeetserver.application.bakery.BakeryQueryService;
+import kr.co.breadfeetserver.infra.util.ApiResponseWrapper;
+import kr.co.breadfeetserver.presentation.bakery.dto.request.BakeryCursorCommand;
+import kr.co.breadfeetserver.presentation.bakery.dto.response.BakeryListResponse;
+import kr.co.breadfeetserver.presentation.support.CursorResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/bakeries")
+public class BakeryQueryController {
+
+    private final BakeryQueryService bakeryQueryService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponseWrapper<CursorResponse<BakeryListResponse>>> getBakeryList(
+            @RequestParam(required = false, defaultValue = "0") Long cursor,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        BakeryCursorCommand command = new BakeryCursorCommand(cursor, size);
+
+        CursorResponse<BakeryListResponse> response = bakeryQueryService.getBakeryList(
+                command);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponseWrapper.success(HttpStatus.OK, "빵집 목록 조회 성공",
+                        response));
+    }
+}

--- a/src/main/java/kr/co/breadfeetserver/presentation/bakery/dto/request/AddressCreateRequest.java
+++ b/src/main/java/kr/co/breadfeetserver/presentation/bakery/dto/request/AddressCreateRequest.java
@@ -1,7 +1,7 @@
 package kr.co.breadfeetserver.presentation.bakery.dto.request;
 
 import kr.co.breadfeetserver.domain.bakery.AddressJpaVO;
-import kr.co.breadfeetserver.global.annotation.IsEssential;
+import kr.co.breadfeetserver.presentation.annotation.IsEssential;
 
 public record AddressCreateRequest(
         @IsEssential(message = "상세 주소가 누락되었습니다.") String detail,

--- a/src/main/java/kr/co/breadfeetserver/presentation/bakery/dto/request/AddressUpdateRequest.java
+++ b/src/main/java/kr/co/breadfeetserver/presentation/bakery/dto/request/AddressUpdateRequest.java
@@ -1,7 +1,7 @@
 package kr.co.breadfeetserver.presentation.bakery.dto.request;
 
 import kr.co.breadfeetserver.domain.bakery.AddressJpaVO;
-import kr.co.breadfeetserver.global.annotation.IsEssential;
+import kr.co.breadfeetserver.presentation.annotation.IsEssential;
 
 public record AddressUpdateRequest(
         @IsEssential(message = "상세 주소가 누락되었습니다.") String detail,

--- a/src/main/java/kr/co/breadfeetserver/presentation/bakery/dto/request/BakeryCreateRequest.java
+++ b/src/main/java/kr/co/breadfeetserver/presentation/bakery/dto/request/BakeryCreateRequest.java
@@ -1,8 +1,8 @@
 package kr.co.breadfeetserver.presentation.bakery.dto.request;
 
 import kr.co.breadfeetserver.domain.bakery.Bakery;
-import kr.co.breadfeetserver.global.annotation.IsEssential;
-import kr.co.breadfeetserver.global.annotation.PhoneNumberPattern;
+import kr.co.breadfeetserver.presentation.annotation.IsEssential;
+import kr.co.breadfeetserver.presentation.annotation.PhoneNumberPattern;
 
 public record BakeryCreateRequest(
         @IsEssential String name,

--- a/src/main/java/kr/co/breadfeetserver/presentation/bakery/dto/request/BakeryCursorCommand.java
+++ b/src/main/java/kr/co/breadfeetserver/presentation/bakery/dto/request/BakeryCursorCommand.java
@@ -1,0 +1,13 @@
+package kr.co.breadfeetserver.presentation.bakery.dto.request;
+
+import jakarta.validation.constraints.Min;
+import kr.co.breadfeetserver.presentation.annotation.CursorSize;
+
+public record BakeryCursorCommand(
+        @Min(0)
+        Long cursor,
+        @CursorSize
+        int size
+) {
+
+}

--- a/src/main/java/kr/co/breadfeetserver/presentation/bakery/dto/request/BakeryUpdateRequest.java
+++ b/src/main/java/kr/co/breadfeetserver/presentation/bakery/dto/request/BakeryUpdateRequest.java
@@ -1,8 +1,8 @@
 package kr.co.breadfeetserver.presentation.bakery.dto.request;
 
 import kr.co.breadfeetserver.domain.bakery.Bakery;
-import kr.co.breadfeetserver.global.annotation.IsEssential;
-import kr.co.breadfeetserver.global.annotation.PhoneNumberPattern;
+import kr.co.breadfeetserver.presentation.annotation.IsEssential;
+import kr.co.breadfeetserver.presentation.annotation.PhoneNumberPattern;
 
 public record BakeryUpdateRequest(
         @IsEssential long bakeryId,

--- a/src/main/java/kr/co/breadfeetserver/presentation/bakery/dto/response/AddressResponse.java
+++ b/src/main/java/kr/co/breadfeetserver/presentation/bakery/dto/response/AddressResponse.java
@@ -1,0 +1,20 @@
+package kr.co.breadfeetserver.presentation.bakery.dto.response;
+
+public record AddressResponse(
+        String detail,
+        String lotNumber,
+        String roadAddress
+) {
+
+    public static AddressResponse of(
+            String detail,
+            String lotNumber,
+            String roadAddress
+    ) {
+        return new AddressResponse(
+                detail,
+                lotNumber,
+                roadAddress
+        );
+    }
+}

--- a/src/main/java/kr/co/breadfeetserver/presentation/bakery/dto/response/BakeryDetailResponse.java
+++ b/src/main/java/kr/co/breadfeetserver/presentation/bakery/dto/response/BakeryDetailResponse.java
@@ -1,0 +1,32 @@
+package kr.co.breadfeetserver.presentation.bakery.dto.response;
+
+import kr.co.breadfeetserver.domain.bakery.Bakery;
+import kr.co.breadfeetserver.presentation.annotation.IsEssential;
+import kr.co.breadfeetserver.presentation.annotation.PhoneNumberPattern;
+
+public record BakeryDetailResponse(
+        @IsEssential String name,
+        AddressResponse address,
+        String imageUrl,
+        @PhoneNumberPattern String phoneNumber,
+        String businessHours,
+        Long reviewCount,
+        Double averageRating
+) {
+
+    public static BakeryDetailResponse from(Bakery bakery) {
+        return new BakeryDetailResponse(
+                bakery.getName(),
+                AddressResponse.of(
+                        bakery.getAddress().getDetail(),
+                        bakery.getAddress().getLotNumber(),
+                        bakery.getAddress().getRoadAddress()
+                ),
+                bakery.getImageUrl(),
+                bakery.getPhoneNumber(),
+                bakery.getBusinessHours(),
+                0L,
+                0.0
+        );
+    }
+}

--- a/src/main/java/kr/co/breadfeetserver/presentation/bakery/dto/response/BakeryListResponse.java
+++ b/src/main/java/kr/co/breadfeetserver/presentation/bakery/dto/response/BakeryListResponse.java
@@ -1,0 +1,38 @@
+package kr.co.breadfeetserver.presentation.bakery.dto.response;
+
+import kr.co.breadfeetserver.domain.bakery.Bakery;
+import kr.co.breadfeetserver.global.dto.Cursorable;
+
+public record BakeryListResponse(
+        Long bakeryId,
+        String name,
+        AddressResponse address,
+        String imageUrl,
+        Long reviewCount,
+        Double averageRating
+) implements Cursorable {
+
+    public static BakeryListResponse from(
+            Bakery bakery,
+            String detail,
+            String lotNumber,
+            String roadAddress,
+            Long reviewCount,
+            Double averageRating
+    ) {
+        return new BakeryListResponse(
+                bakery.getId(),
+                bakery.getName(),
+                AddressResponse.of(
+                        detail, lotNumber, roadAddress),
+                bakery.getImageUrl(),
+                reviewCount,
+                averageRating
+        );
+    }
+
+    @Override
+    public Long getCursorId() {
+        return this.bakeryId;
+    }
+}

--- a/src/main/java/kr/co/breadfeetserver/presentation/diary/dto/request/DiaryCreateRequest.java
+++ b/src/main/java/kr/co/breadfeetserver/presentation/diary/dto/request/DiaryCreateRequest.java
@@ -1,11 +1,9 @@
 package kr.co.breadfeetserver.presentation.diary.dto.request;
 
+import java.time.LocalDateTime;
 import kr.co.breadfeetserver.domain.bakery.AddressJpaVO;
 import kr.co.breadfeetserver.domain.diary.Diary;
-import kr.co.breadfeetserver.global.annotation.IsEssential;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import kr.co.breadfeetserver.presentation.annotation.IsEssential;
 
 public record DiaryCreateRequest(
         @IsEssential Boolean isPublic,
@@ -15,7 +13,8 @@ public record DiaryCreateRequest(
         LocalDateTime visitDate,
         String content
 ) {
-    public Diary toEntity(Long memberId){
+
+    public Diary toEntity(Long memberId) {
         return Diary.builder()
                 .isPublic(isPublic)
                 .score(score)

--- a/src/main/java/kr/co/breadfeetserver/presentation/diary/dto/request/DiaryUpdateRequest.java
+++ b/src/main/java/kr/co/breadfeetserver/presentation/diary/dto/request/DiaryUpdateRequest.java
@@ -1,14 +1,9 @@
 package kr.co.breadfeetserver.presentation.diary.dto.request;
 
-import kr.co.breadfeetserver.domain.bakery.AddressJpaVO;
-import kr.co.breadfeetserver.domain.bakery.Bakery;
-import kr.co.breadfeetserver.domain.diary.Diary;
-import kr.co.breadfeetserver.global.annotation.IsEssential;
-import kr.co.breadfeetserver.global.annotation.PhoneNumberPattern;
-import kr.co.breadfeetserver.presentation.bakery.dto.request.AddressUpdateRequest;
-
-import java.time.LocalDate;
 import java.time.LocalDateTime;
+import kr.co.breadfeetserver.domain.diary.Diary;
+import kr.co.breadfeetserver.presentation.annotation.IsEssential;
+import kr.co.breadfeetserver.presentation.bakery.dto.request.AddressUpdateRequest;
 
 public record DiaryUpdateRequest(
         @IsEssential long diaryId,

--- a/src/main/java/kr/co/breadfeetserver/presentation/diary/dto/response/DiaryResponse.java
+++ b/src/main/java/kr/co/breadfeetserver/presentation/diary/dto/response/DiaryResponse.java
@@ -1,14 +1,10 @@
 package kr.co.breadfeetserver.presentation.diary.dto.response;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import kr.co.breadfeetserver.domain.bakery.AddressJpaVO;
-import kr.co.breadfeetserver.domain.diary.Diary;
-import kr.co.breadfeetserver.domain.diary.Hashtag;
-import kr.co.breadfeetserver.domain.diary.PictureUrl;
-import lombok.Builder;
-
 import java.time.LocalDateTime;
 import java.util.List;
+import kr.co.breadfeetserver.domain.bakery.AddressJpaVO;
+import kr.co.breadfeetserver.domain.diary.Diary;
+import lombok.Builder;
 
 @Builder
 public record DiaryResponse(
@@ -24,7 +20,8 @@ public record DiaryResponse(
         List<String> hashtags,
         List<String> pictureUrls
 ) {
-    public static DiaryResponse from(Diary diary, List<String> hashtags, List<String> pictureUrls){
+
+    public static DiaryResponse from(Diary diary, List<String> hashtags, List<String> pictureUrls) {
         return DiaryResponse.builder()
                 .id(diary.getId())
                 .address(diary.getAddress())

--- a/src/main/java/kr/co/breadfeetserver/presentation/support/CursorResponse.java
+++ b/src/main/java/kr/co/breadfeetserver/presentation/support/CursorResponse.java
@@ -1,0 +1,45 @@
+package kr.co.breadfeetserver.presentation.support;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Slice;
+
+@Getter
+public class CursorResponse<T> {
+
+    private final List<T> content;
+    private final SliceInfo sliceInfo;
+
+    private CursorResponse(final List<T> content, final SliceInfo sliceInfo) {
+        this.content = (content == null) ? java.util.Collections.emptyList() : content;
+        this.sliceInfo = sliceInfo;
+    }
+
+    public static <T> CursorResponse<T> of(final Slice<T> slice, final Long cursor) {
+        SliceInfo pageInfo = SliceInfo.builder()
+                .size(slice.getSize())
+                .numberOfElements(slice.getNumberOfElements())
+                .last(slice.isLast())
+                .empty(slice.isEmpty())
+                .cursor(cursor)
+                .build();
+        return new CursorResponse<>(slice.getContent(), pageInfo);
+    }
+
+    record SliceInfo(
+            int size,
+            int numberOfElements,
+            boolean last,
+            boolean empty,
+            @JsonInclude(NON_NULL) Long cursor
+    ) {
+
+        @Builder
+        public SliceInfo {
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,7 +46,6 @@ spring:
         order_inserts: true
         order_updates: true
         batch_versioned_data: true
-        dialect: org.hibernate.dialect.MySQLDialect
         default_batch_fetch_size: 100
   flyway:
     enabled: false

--- a/src/main/resources/logback/logback-local.xml
+++ b/src/main/resources/logback/logback-local.xml
@@ -11,6 +11,8 @@
 
     <logger name="org.springframework" level="INFO"/>
   <logger name="kr.co.breadfeetserver" level="INFO"/>
+  <logger name="org.hibernate.SQL" level="DEBUG"/>
+  <logger name="org.hibernate.type.descriptor.sql" level="TRACE"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>

--- a/src/test/java/kr/co/breadfeetserver/domain/bakery/query/BakeryJdbcRepositoryImplTest.java
+++ b/src/test/java/kr/co/breadfeetserver/domain/bakery/query/BakeryJdbcRepositoryImplTest.java
@@ -1,0 +1,153 @@
+package kr.co.breadfeetserver.domain.bakery.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import kr.co.breadfeetserver.domain.bakery.query.mapper.BakeryRowMapper;
+import kr.co.breadfeetserver.presentation.bakery.dto.request.BakeryCursorCommand;
+import kr.co.breadfeetserver.presentation.bakery.dto.response.AddressResponse;
+import kr.co.breadfeetserver.presentation.bakery.dto.response.BakeryListResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Slice;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+
+@ExtendWith(MockitoExtension.class)
+class BakeryJdbcRepositoryImplTest {
+
+    @Mock
+    private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    private BakeryJdbcRepository bakeryJdbcRepository;
+
+    @BeforeEach
+    void setUp() {
+        bakeryJdbcRepository = new BakeryJdbcRepositoryImpl(namedParameterJdbcTemplate);
+    }
+
+    private BakeryListResponse createBakeryListResponse(Long id) {
+        return new BakeryListResponse(
+                id,
+                "빵집 " + id,
+                new AddressResponse("상세 주소 " + id, "지번 주소 " + id, "도로명 주소 " + id),
+                "이미지 URL " + id,
+                0L,
+                0.0
+        );
+    }
+
+    @Test
+    @DisplayName("첫 페이지를 조회한다 (커서가 null).")
+    void findFirstPage() {
+        // given
+        int size = 5;
+        BakeryCursorCommand command = new BakeryCursorCommand(null, size);
+
+        List<BakeryListResponse> mockedData = new ArrayList<>();
+        for (long i = 20; i >= 15; i--) {
+            mockedData.add(createBakeryListResponse(i));
+        }
+
+        when(namedParameterJdbcTemplate.query(any(String.class), any(SqlParameterSource.class),
+                any(BakeryRowMapper.class)))
+                .thenReturn(mockedData);
+
+        // when
+        Slice<BakeryListResponse> result = bakeryJdbcRepository.findAll(command);
+
+        // then
+        assertThat(result.getContent()).hasSize(size);
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.getContent().get(0).bakeryId()).isEqualTo(20L);
+        assertThat(result.getContent().get(4).bakeryId()).isEqualTo(16L);
+    }
+
+    @Test
+    @DisplayName("다음 페이지를 조회한다 (커서 사용).")
+    void findNextPage() {
+        // given
+        int size = 5;
+        Long cursor = 16L;
+        BakeryCursorCommand command = new BakeryCursorCommand(cursor, size);
+
+        List<BakeryListResponse> mockedData = new ArrayList<>();
+        for (long i = 15; i >= 10; i--) {
+            mockedData.add(createBakeryListResponse(i));
+        }
+
+        when(namedParameterJdbcTemplate.query(any(String.class), any(SqlParameterSource.class),
+                any(BakeryRowMapper.class)))
+                .thenReturn(mockedData);
+
+        // when
+        Slice<BakeryListResponse> result = bakeryJdbcRepository.findAll(command);
+
+        // then
+        assertThat(result.getContent()).hasSize(size);
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.getContent().get(0).bakeryId()).isEqualTo(15L);
+        assertThat(result.getContent().get(4).bakeryId()).isEqualTo(11L);
+    }
+
+    @Test
+    @DisplayName("마지막 페이지를 조회한다.")
+    void findLastPage() {
+        // given
+        int size = 5;
+        Long cursor = 6L;
+        BakeryCursorCommand command = new BakeryCursorCommand(cursor, size);
+
+        List<BakeryListResponse> mockedData = new ArrayList<>();
+        for (long i = 5; i >= 1; i--) {
+            mockedData.add(createBakeryListResponse(i));
+        }
+
+        when(namedParameterJdbcTemplate.query(any(String.class), any(SqlParameterSource.class),
+                any(BakeryRowMapper.class)))
+                .thenReturn(mockedData);
+
+        // when
+        Slice<BakeryListResponse> result = bakeryJdbcRepository.findAll(command);
+
+        // then
+        assertThat(result.getContent()).hasSize(size);
+        assertThat(result.hasNext()).isFalse();
+        assertThat(result.getContent().get(0).bakeryId()).isEqualTo(5L);
+        assertThat(result.getContent().get(4).bakeryId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("조회할 데이터가 페이지 크기보다 적은 경우를 테스트한다.")
+    void findPartialLastPage() {
+        // given
+        int size = 5;
+        Long cursor = 4L;
+        BakeryCursorCommand command = new BakeryCursorCommand(cursor, size);
+
+        List<BakeryListResponse> mockedData = new ArrayList<>();
+        for (long i = 3; i >= 1; i--) {
+            mockedData.add(createBakeryListResponse(i));
+        }
+
+        when(namedParameterJdbcTemplate.query(any(String.class), any(SqlParameterSource.class),
+                any(BakeryRowMapper.class)))
+                .thenReturn(mockedData);
+
+        // when
+        Slice<BakeryListResponse> result = bakeryJdbcRepository.findAll(command);
+
+        // then
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.hasNext()).isFalse();
+        assertThat(result.getContent().get(0).bakeryId()).isEqualTo(3L);
+        assertThat(result.getContent().get(2).bakeryId()).isEqualTo(1L);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,19 +11,13 @@ server:
 
 spring:
   datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    hikari:
-      maximum-pool-size: 20
-      minimum-idle: 10
-      connection-timeout: 3000
-      validation-timeout: 3000
-      idle-timeout: 300000
-      max-lifetime: 600000
-      keepalive-time: 60000
-      connection-test-query: SELECT 1
+    url: jdbc:h2:mem:testdb
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+    h2:
+      console:
+        enabled: true
   servlet:
     multipart:
       max-file-size: ${MAX_FILE_SIZE}
@@ -32,13 +26,13 @@ spring:
     open-in-view: false
     show-sql: false
     hibernate:
-      ddl-auto: none
+      ddl-auto: create-drop
     properties:
       hibernate:
-        show_sql: false
-        format_sql: false
-        highlight_sql: false
-        use_sql_comments: false
+        show_sql: true
+        format_sql: true
+        highlight_sql: true
+        use_sql_comments: true
         jdbc:
           time_zone: UTC
           batch_size: 50

--- a/src/test/resources/logback/logback-test.xml
+++ b/src/test/resources/logback/logback-test.xml
@@ -11,6 +11,8 @@
 
     <logger name="org.springframework" level="INFO"/>
     <logger name="io.dodn.springboot" level="DEBUG"/>
+    <logger name="org.hibernate.SQL" level="DEBUG"/>
+    <logger name="org.hibernate.type.descriptor.sql" level="TRACE"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
## ✨ 구현한 기능
- resolve #6 
- Bakery 목록 조회 기능
- Bakery 상세 조회 기능

## 📢 논의하고 싶은 내용
- 목록 조회 같이 성능이 중요시 되는 쿼리는 JPA의 생명주기가 필요없다고 판단하고, 학습을 해보고 싶어서 JDBC와 JPA를 결합한 형태로 사용했습니다.

## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bakery listing API with cursor-based pagination and bakery detail lookup.
  * Paginated responses now include cursor metadata for seamless next-page fetching.

* **Chores**
  * Testing infrastructure switched to an in-memory H2 database.
  * Validation annotations reorganized to the presentation layer; logging verbosity for SQL increased.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->